### PR TITLE
Remove debug fallback color

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -28,8 +28,8 @@ body.about-page {
 
 body.publications-page {
     background-image: url('../assets/publication_background.JPG');
-    /* Debug: Add a fallback color to verify the selector */
-    background-color: #ffcccc; /* Light red if image fails */
+    /* Fallback color if the image fails to load */
+    background-color: #f5f5f5;
 }
 
 body.research-page {


### PR DESCRIPTION
## Summary
- drop troubleshooting red background from `body.publications-page`
- add neutral fallback color for the publication page background

## Testing
- `tidy --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68448c46d2a083278bb8899c6e38fcbd