### PR TITLE
Add meta descriptions for site pages

### DIFF
--- a/about.html
+++ b/about.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Biography of Megh Bahadur KC detailing education, work experience and research interests in sustainable transportation.">
     <title>About - Megh Bahadur KC</title>
     <link rel="stylesheet" href="css/style.css">
 </head>

--- a/contact.html
+++ b/contact.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
     <title>Contact</title>
+    <meta name="description" content="Contact form and links to connect with Megh Bahadur KC via email and social networks.">
     <link rel="stylesheet" href="css/style.css">
 </head>
 <body class="contact-page">

--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Homepage of Megh Bahadur KC, Ph.D. candidate researching electric buses and smart mobility.">
     <title>Home - Megh Bahadur KC</title>
     <link rel="stylesheet" href="css/style.css">
 </head>

--- a/publications.html
+++ b/publications.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Compilation of Megh Bahadur KC's journal articles, papers under review and conference presentations.">
     <title>Publications - Megh Bahadur KC</title>
     <link rel="stylesheet" href="css/style.css">
 </head>

--- a/research.html
+++ b/research.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Overview of Megh Bahadur KC's ongoing and past research projects in transportation optimization and mobility.">
     <title>Research - Megh Bahadur KC</title>
     <link rel="stylesheet" href="css/style.css">
 </head>

--- a/skills_awards.html
+++ b/skills_awards.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Highlights Megh Bahadur KC's technical skills and academic awards.">
     <title>Skills & Awards - Megh Bahadur KC</title>
     <link rel="stylesheet" href="css/style.css">
 </head>


### PR DESCRIPTION
## Summary
- add meta descriptions for home, about, publications, research, skills & awards, and contact pages

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68448d7206fc83278f2ca5c4d91e4753